### PR TITLE
update support for latest generator

### DIFF
--- a/open-rpc-generator-config.json
+++ b/open-rpc-generator-config.json
@@ -5,7 +5,11 @@
         {
             "type": "docs",
             "name": "execution-apis",
-            "language": "gatsby"
+            "language": "gatsby",
+            "extraConfig": {
+                "gatsbyConfigPath": "./docs/config",
+                "docsPath": "./docs/reference"
+            }
         }
     ]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
       },
       "devDependencies": {
         "@graphql-inspector/core": "~3.3.0",
-        "@open-rpc/generator": "^2.0.1",
+        "@open-rpc/generator": "^2.1.0",
         "@open-rpc/schema-utils-js": "^2.1.2",
         "gatsby": "^5.14.3",
         "gh-pages": "~4.0.0",
@@ -3223,7 +3223,9 @@
       }
     },
     "node_modules/@open-rpc/generator": {
-      "version": "2.0.1",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@open-rpc/generator/-/generator-2.1.0.tgz",
+      "integrity": "sha512-K1NLJzBGdD6wVQXl73zonktOoo6dXSTHm2fP4Rx5QiWJREr8gutvXMh2Dd6yZcDsLmC8F7BcFZm4bwss0JJ0Tw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "build": "npm run build:spec",
     "build:spec": "node scripts/build.js",
     "build:docs": "npm run generate-clients && npm run build:docs:gatsby",
-    "build:docs:gatsby": "cp docs/config/gatsby-config.js build/docs/gatsby && cd build/docs/gatsby && npm install && gatsby build --prefix-paths",
+    "build:docs:gatsby": "cd build/docs/gatsby && npm install && gatsby build --prefix-paths",
     "lint": "node scripts/build.js && node scripts/validate.js && node scripts/graphql-validate.js",
     "clean": "rm -rf build && mkdir -p build",
     "generate-clients": "mkdir -p build && open-rpc-generator generate -c open-rpc-generator-config.json",
@@ -28,7 +28,7 @@
   "homepage": "https://github.com/ethereum/execution-apis#readme",
   "devDependencies": {
     "@graphql-inspector/core": "~3.3.0",
-    "@open-rpc/generator": "^2.0.1",
+    "@open-rpc/generator": "^2.1.0",
     "@open-rpc/schema-utils-js": "^2.1.2",
     "gatsby": "^5.14.3",
     "gh-pages": "~4.0.0",


### PR DESCRIPTION
This change allows for documentation assets to be copied by the generator into the proper build locations, for the gatsby generator